### PR TITLE
Set nfs conf options in mountd block, enable manage-gids-option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ nfs_server_enabled: "yes"
 # If nfs_service_managed is False then we don't restart/start nfs
 nfs_service_managed: True
 nfsd_threads: 32
+nfs_conf_mountd: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,6 @@ nfs_server_enabled: "yes"
 # If nfs_service_managed is False then we don't restart/start nfs
 nfs_service_managed: True
 nfsd_threads: 32
-nfs_conf_mountd: {}
+nfs_conf_mountd: {
+  "manage-gids":"yes"
+}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,8 +6,7 @@
   when: nfs_service_managed and ansible_distribution_major_version == "7" and ansible_os_family == "RedHat"
 
 - name: restart nfs-server
-  service: 
+  service:
      name: "{{ nfs_server_daemon }}"
      state: restarted
   when: nfs_service_managed
-

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -50,6 +50,13 @@ provisioner:
       nfsservers:
         nfs_exports:
           - "/export/nfs_test nfs-client(rw,sync,no_root_squash)"
+        nfs_conf_mountd:
+          manage-gids: "yes"
       nfsclients: []
 verifier:
   name: ansible
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -50,8 +50,6 @@ provisioner:
       nfsservers:
         nfs_exports:
           - "/export/nfs_test nfs-client(rw,sync,no_root_squash)"
-        nfs_conf_mountd:
-          manage-gids: "yes"
       nfsclients: []
 verifier:
   name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -39,3 +39,15 @@
       args:
         warn: false
       when: ansible_distribution_major_version == '7'
+
+- name: Verify that the mountd options are set correctly
+  hosts: nfsservers
+  tasks:
+    - name: Check the manage-gids-option
+      command: 'nfsconf --isset mountd manage-gids'
+      when: ansible_distribution_major_version == '8'
+    - name: Check the manage-gids-option
+      shell: "sed -n '/[^#]\\[mountd\\]/,/\\[.*\\]/p' /etc/nfs.conf | awk -F= '/manage-gids/{print $2}'"
+      args:
+        warn: false
+      when: ansible_distribution_major_version == '7'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   notify: restart nfs-server
 
 - name: Ensure nfs is running.
-  service: 
+  service:
       name: "{{ nfs_server_daemon }}"
       state: "{{ nfs_server_state }}"
       enabled: "{{ nfs_server_enabled }}"

--- a/templates/nfs.conf.j2
+++ b/templates/nfs.conf.j2
@@ -1,3 +1,10 @@
 # {{ ansible_managed }}
 [nfsd]
   threads={{ nfsd_threads }}
+
+{% if nfs_conf_mountd|length > 0 %}
+[mountd]
+{% for key, value in nfs_conf_mountd.items() %}
+  {{ key }}={{ value }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This PR allows for setting options in the nfs.conf's mountd-block.

By default it now sets `manage-gids=yes`, which allows nfs server to do a gid lookup instead of relying on groups provided by the NFS protocol. As NFS servers should have gid information through nis or sssd, this should not be a problem.

This fixes mounting problems when users have more than 16 groups. See [mountd-man pages](https://linux.die.net/man/8/mountd) for more information.

This feature can be overwritten by setting `nfs_conf_mountd: {}` in vars.